### PR TITLE
Error: You must pass a scope and parentPath unless traversing a Program/File. Instead of that you tried to traverse a undefined node without passing scope and parentPath.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ module.exports = function index(
   options: Options
 ): string | null | undefined | void {
   const ast = options.noRecastWorkaround
-    ? api.jscodeshift(fileInfo.source).get()
+    ? api.jscodeshift(fileInfo.source).get().value
     : recast.parse(fileInfo.source, {
         parser: require('recast/parsers/babel'),
       })


### PR DESCRIPTION
Got an error using `noRecastWorkaround`:

```
Error: You must pass a scope and parentPath unless traversing a Program/File. Instead of that you tried to traverse a undefined node without passing scope and parentPath.
    at traverse (/Users/coderaiser/putout/node_modules/@codemodsquad/asyncify/node_modules/@babel/traverse/lib/index.js:53:13)
    at index (/Users/coderaiser/putout/node_modules/@codemodsquad/asyncify/index.js:24:28)
    at module.exports (/Users/coderaiser/putout/node_modules/@codemodsquad/asyncify/noRecastWorkaround.js:13:28)
```

The thing is `AST` located in `api.jscodeshift(fileInfo.source).get().value`