### PR TITLE
fix: avoid creating invalid syntax async get method

### DIFF
--- a/src/asyncify.ts
+++ b/src/asyncify.ts
@@ -8,9 +8,10 @@ import unwindPromiseChain from './util/unwindPromiseChain'
 import finalCleanup from './util/finalCleanup'
 import codeLength from './util/codeLength'
 import babelBugWorkarounds from './util/babelBugWorkarounds'
+import isGetterOrSetter from './util/isGetterOrSetter'
 
 function asyncifyFunction(path: NodePath<t.Function>): void {
-  if (returnsOrAwaitsPromises(path)) {
+  if (returnsOrAwaitsPromises(path) && !isGetterOrSetter(path)) {
     path.node.async = true
   }
   const chains = findPromiseChains(path)

--- a/src/util/isGetterOrSetter.ts
+++ b/src/util/isGetterOrSetter.ts
@@ -1,0 +1,12 @@
+import * as t from '@babel/types'
+import { NodePath } from '@babel/traverse'
+
+export default function isGetterOrSetter(
+  path: NodePath<t.Function> | null
+): boolean {
+  return (
+    path !== null &&
+    (path.isObjectMethod() || path.isClassMethod()) &&
+    (path.node.kind === 'get' || path.node.kind === 'set')
+  )
+}

--- a/src/util/shouldIgnoreChain.ts
+++ b/src/util/shouldIgnoreChain.ts
@@ -5,6 +5,7 @@ import iterateChain from './iterateChain'
 import getThenHandler from './getThenHandler'
 import getCatchHandler from './getCatchHandler'
 import getFinallyHandler from './getFinallyHandler'
+import isGetterOrSetter from './isGetterOrSetter'
 
 function chainLength(path: NodePath<t.CallExpression>): number {
   let length = 0
@@ -36,9 +37,10 @@ export default function shouldIgnoreChain(
 ): boolean {
   const { parentPath } = path
   if (
-    !parentPath.isReturnStatement() &&
-    !parentPath.isAwaitExpression() &&
-    !parentPath.isFunction()
+    (!parentPath.isReturnStatement() &&
+      !parentPath.isAwaitExpression() &&
+      !parentPath.isFunction()) ||
+    isGetterOrSetter(path.getFunctionParent())
   ) {
     if (chainLength(path) <= 2 && !hasComplexHandlers(path)) return true
   }

--- a/src/util/unwindPromiseChain.ts
+++ b/src/util/unwindPromiseChain.ts
@@ -9,14 +9,16 @@ import { unwindThen } from './unwindThen'
 import unwindFinally from './unwindFinally'
 import parentStatement from './parentStatement'
 import replaceWithImmediatelyInvokedAsyncArrowFunction from './replaceWithImmediatelyInvokedAsyncArrowFunction'
+import isGetterOrSetter from './isGetterOrSetter'
 
 export default function unwindPromiseChain(
   path: NodePath<t.CallExpression>
 ): void {
   if (
-    !path.parentPath.isAwaitExpression() &&
-    !path.parentPath.isReturnStatement() &&
-    !path.parentPath.isFunction()
+    (!path.parentPath.isAwaitExpression() &&
+      !path.parentPath.isReturnStatement() &&
+      !path.parentPath.isFunction()) ||
+    isGetterOrSetter(path.getFunctionParent())
   ) {
     path = replaceWithImmediatelyInvokedAsyncArrowFunction(path)[1]
   }

--- a/test/fixtures/bugs_GetterAndSetterCannotBeAsync.ts
+++ b/test/fixtures/bugs_GetterAndSetterCannotBeAsync.ts
@@ -1,0 +1,47 @@
+export const input = `
+class A {
+  method() {return p.then(x => f(x))}
+  get prop() {return p.then(x => f(x))}
+  set prop(val) {return p.then(x => f(x))}
+  get longchain() {return p.then(x => f(x)).then(y => g(y)).then(z => h(z))}
+}
+const obj = {
+  method() {return p.then(x => f(x))},
+  get prop() {return p.then(x => f(x))},
+  set prop(val) {return p.then(x => f(x))}
+};
+`
+export const expected = `
+class A {
+  async method() {
+    const x = await p;
+    return f(x);
+  }
+  get prop() {
+    return p.then(x => f(x))
+  }
+  set prop(val) {
+    return p.then(x => f(x))
+  }
+  get longchain() {
+    return (async () => {
+      const x = await p
+      const y = await f(x)
+      const z = await g(y)
+      return await h(z)
+    })()
+  }
+}
+const obj = {
+  async method() {
+    const x = await p;
+    return f(x);
+  },
+  get prop() {
+    return p.then(x => f(x))
+  },
+  set prop(val) {
+    return p.then(x => f(x))
+  }
+};
+`


### PR DESCRIPTION
Previously, asyncify would convert a getter/setter into an invalid async getter/setter.

Input:

```js
class A {
  method() {return p.then(x => f(x))}
  get prop() {return p.then(x => f(x))}
  set prop(val) {return p.then(x => f(x))}
  get longchain() {return p.then(x => f(x)).then(y => g(y)).then(z => h(z))}
}
const obj = {
  method() {return p.then(x => f(x))},
  get prop() {return p.then(x => f(x))},
  set prop(val) {return p.then(x => f(x))}
};
```

Output before this PR. Note that `get prop()` is converted to `async get prop()`, which is invalid ECMAScript and invalid TypeScript:

```js
class A {
  async method() {
    const x = await p;
    return f(x);
  }
  async get prop() {
    const x = await p;
    return f(x);
  }
  async set prop(val) {
    const x = await p;
    return f(x);
  }
  async get longchain() {
    const x = await p;
    const y = await f(x);
    const z = await g(y);
    return h(z);
  }
}
const obj = {
  async method() {
    const x = await p;
    return f(x);
  },
  async get prop() {
    const x = await p;
    return f(x);
  },
  async set prop(val) {
    const x = await p;
    return f(x);
  }
};
```

Output after this PR: `get` and `set` methods are not converted to async, and instead an immediately invoked function expression (IIFE) is created, or the promise chain is ignored, depending on the length of the chain.

```js
class A {
  async method() {
    const x = await p;
    return f(x);
  }
  get prop() {return p.then(x => f(x))}
  set prop(val) {return p.then(x => f(x))}
  get longchain() {return (async () => {
    const x = await p;
    const y = await f(x);
    const z = await g(y);
    return await h(z);
  })();}
}
const obj = {
  async method() {
    const x = await p;
    return f(x);
  },
  get prop() {return p.then(x => f(x))},
  set prop(val) {return p.then(x => f(x))}
};
```

I made a similar PR here https://github.com/sgilroy/async-await-codemod/pull/21 but then I found this repo where all the action seems to be

Note: the precommit hook failed in `tsc --noEmit` on files that I did not modify (with errors like `Type 'NodePath<Node>' is not assignable to type 'T extends Program ? null : NodePath<Node>'`), so I had to `git commit --no-verify`. Probably I `npm install`ed a different version of TypeScript than you use. Please advise on how to continue.